### PR TITLE
Feature/search-result-range-increase

### DIFF
--- a/rapid_moment_navigator.py
+++ b/rapid_moment_navigator.py
@@ -4013,14 +4013,13 @@ except Exception as e:
                     item_copy['search_type'] = 'individual'
                     matches.append(item_copy)
         
-        # Second pass: consecutive search (smart fallback approach)
-        if self.preferences.get("consecutive_search_enabled", True) and len(subtitle_items) > 1:
-            consecutive_enabled = self.preferences.get("consecutive_search_enabled", True)
-            always_consecutive = self.preferences.get("always_consecutive_search", False)
-            
+        # Second pass: consecutive search (automatic fallback + optional always mode)
+        always_consecutive = self.preferences.get("always_consecutive_search", False)
+        
+        if len(subtitle_items) > 1:
             # Run consecutive search if:
             # 1. Always consecutive is enabled, OR
-            # 2. No individual results were found (fallback mode)
+            # 2. No individual results were found (automatic fallback - no performance cost)
             should_run_consecutive = always_consecutive or len(matches) == 0
             
             if should_run_consecutive:

--- a/rapid_moment_navigator.py
+++ b/rapid_moment_navigator.py
@@ -1468,8 +1468,11 @@ class RapidMomentNavigator:
                     
                     # Remove HTML tags for searching
                     clean_text = re.sub(r'<[^>]+>', '', text)
+                    # Normalize line separators (including Unicode ones like \u2028 from DaVinci Resolve)
+                    normalized_text = clean_text.replace('\u2028', ' ').replace('\u2029', ' ').replace('\n', ' ').replace('\r', ' ')
+                    normalized_text = re.sub(r'\s+', ' ', normalized_text).strip()
                     
-                    if keyword.lower() in clean_text.lower():
+                    if keyword.lower() in normalized_text.lower():
                         # Convert comma separator to period for MPC
                         mpc_start_time = start_time.replace(',', '.')
                         
@@ -3955,11 +3958,15 @@ except Exception as e:
     def _search_subtitle_items(self, subtitle_items, text_to_find, case_sensitive=False):
         matches = []
         for item in subtitle_items:
+            # Normalize text by handling unicode line separators
+            normalized_text = item['text'].replace('\u2028', ' ').replace('\u2029', ' ').replace('\n', ' ').replace('\r', ' ')
+            normalized_text = re.sub(r'\s+', ' ', normalized_text).strip()
+            
             if case_sensitive:
-                if text_to_find in item['text']:
+                if text_to_find in normalized_text:
                     matches.append(item)
             else:
-                if text_to_find.lower() in item['text'].lower():
+                if text_to_find.lower() in normalized_text.lower():
                     matches.append(item)
                 
         return matches


### PR DESCRIPTION
Made the search results smarter, so it can consecutively search across multiple lines in a single entry. For example:

```
43
00:02:00,987 --> 00:02:04,491
<b>he used to induce lucid
dreams so he could study in his sleep.</b>
```

Normally when searching "lucid dream", it wouldn't have yielded results due to lucid and dreams being on separate lines. Now it will. There is also consecutive entry search capability. The following result would not have been yielded searching "mind awake body asleep", but now will yield the following example result:

```
47
00:02:13,633 --> 00:02:14,200
<b>Mind awake.</b>

48
00:02:15,101 --> 00:02:15,768
<b>Body asleep.</b>
```

It's worth noting that it will only happen if that search term didn't yield any results originally. In this case with the original Mr. Robot transcript, it would happen as desired with the default setting. With the mechanisms, it adds a lot of additional overhead and slows down the search results, but by default, that slow down is worth it if the original mechanism doesn't yield anything while this new mechanism would. It triggers as a fallback. There's a new general setting to make it always trigger, even if there are other results. It's disabled by default as it would likely be a rare edge case that doesn't justify the additional overhead performance compromise. Most of the time if the consecutive search is needed, it will very likely be when there are no results to begin with. The setting is for edge cases where there are results, but one is searching a consecutive search result on top of that, which normally doesn't yield by default.